### PR TITLE
update card head to align head items

### DIFF
--- a/src/components/card.scss
+++ b/src/components/card.scss
@@ -20,6 +20,8 @@
     height: $card-head-height;
     line-height: $card-head-height;
     border-bottom: 1px solid $card-border-color;
+    display: flex;
+    justify-content: space-between;
   }
   &__title {
     display: inline-block;


### PR DESCRIPTION
added display flex and justify-content space-between so the title and the extra slots fits as it's shown at the documentation. Each one to a side and not in the center as it is now